### PR TITLE
Google Scripts for Stepik API

### DIFF
--- a/examples/google-scripts/featured_courses.gs
+++ b/examples/google-scripts/featured_courses.gs
@@ -1,0 +1,35 @@
+function createStepikMenu(e) {
+  SpreadsheetApp.getUi()
+    .createMenu('Stepik')
+    .addItem('Featured Courses', 'collectFeaturedCoursesInfo')
+    .addToUi();
+}
+
+function collectFeaturedCoursesInfo()
+{
+  newSheet = createOrReplaceSheet('Featured Courses')
+  newSheet.appendRow(['ID', 'Title', 'Course Format', 'Target Audience', 'Workload']);
+  newSheet.getRange(1, 1, 1, 5).setFontWeight('bold')
+  page = 1
+  do {
+    response = getApiRequest('courses?is_featured=True&page=' + page);
+    response_json = JSON.parse(response);
+    data = response_json['courses'];
+    for(id in data) {
+      item = data[id]
+      url = '=HYPERLINK("https://stepik.org/course/'+ item.id +'"; "'+ item.id +'")'
+      newSheet.appendRow([url, item.title, item.course_format, item.target_audience, item.workload]);
+    }
+    page++;
+  } while(response_json['meta']['has_next']); 
+}
+
+function createOrReplaceSheet(sheetName){
+  app = SpreadsheetApp.getActive()
+  oldSheet = app.getSheetByName(sheetName);
+  if(oldSheet) {
+    app.deleteSheet(oldSheet);
+  }
+  newSheet = app.insertSheet(sheetName);
+  return newSheet
+}

--- a/examples/google-scripts/stepik.gs
+++ b/examples/google-scripts/stepik.gs
@@ -1,5 +1,5 @@
-var CLIENT_ID = 'n4mnzQGfDEfOhFixwBvLV2mZJJLvf86pzfMMiPF5'
-var CLIENT_SECRET = '40ON9IPJRDAngUkVbGBTEjCBAwc2wB7lV8e71jJUPKabdKq6KBTUBKb1xGkh82KtAI1AqISrL3Zi4sTfhCBVh27YvlV6Y5klpXXV5loUWvuhMSRiN3HRZzVDO0fLBibv'
+var CLIENT_ID = '...'
+var CLIENT_SECRET = '...'
 var API_HOST = 'https://stepik.org/'
 
 var token = getStepikToken()

--- a/examples/google-scripts/stepik.gs
+++ b/examples/google-scripts/stepik.gs
@@ -1,0 +1,36 @@
+var CLIENT_ID = 'n4mnzQGfDEfOhFixwBvLV2mZJJLvf86pzfMMiPF5'
+var CLIENT_SECRET = '40ON9IPJRDAngUkVbGBTEjCBAwc2wB7lV8e71jJUPKabdKq6KBTUBKb1xGkh82KtAI1AqISrL3Zi4sTfhCBVh27YvlV6Y5klpXXV5loUWvuhMSRiN3HRZzVDO0fLBibv'
+var API_HOST = 'https://stepik.org/'
+
+var token = getStepikToken()
+
+function getStepikToken(){
+  tokenUrl = API_HOST + 'oauth2/token/';
+  options = {
+    'method': 'post',
+    'headers': {
+      'Authorization': 'Basic ' + Utilities.base64Encode(CLIENT_ID + ':' + CLIENT_SECRET)
+    },
+    'payload' : {
+      'grant_type': 'client_credentials'
+    },
+  };
+  response = UrlFetchApp.fetch(tokenUrl, options);
+  return JSON.parse(response.getContentText()).access_token 
+}
+
+function getApiRequest(url){
+  options = {
+    'headers': {
+      'Authorization': 'Bearer ' + token
+    }
+  };
+  response = UrlFetchApp.fetch(API_HOST + 'api/' + url, options);
+  return response.getContentText()
+}
+
+function fetchObjectsByPK(objectName, objectPK){  
+  objectUrl = objectName + '/' + objectPK;
+  return getApiRequest(objectUrl)
+}
+


### PR DESCRIPTION
This is an example how to use Stepik API with Google Spreadsheet together.
`stepik.gs` contains common functions that can be used to work with Stepik API.
`featured_courses.gs` contains functions to create the menu `Stepik` and  to generate a report.

Working example is located here: https://docs.google.com/spreadsheets/d/1KyynNoL6pqtnEIXipdaBZnVyq3DIj1gvZyNgKoMGsF8/ 
(in the Stepik Team folders, not in public)

To use this script, you should open script editor in a Google Spreadsheet table (select the menu `Tools / Script editor...`) and copy the files `stepik.gs`  and `featured_courses.gs` there. Then create the trigger to launch the function `createStepikMenu(e)` when opening the table: select the menu `Resources / All your triggers` and add the corresponding trigger manually.