### PR TITLE
Add keep_order option in fetch_objects

### DIFF
--- a/examples/save_course_steps.py
+++ b/examples/save_course_steps.py
@@ -29,7 +29,7 @@ def fetch_object(obj_class, obj_id):
     return response['{}s'.format(obj_class)][0]
 
 
-def fetch_objects(obj_class, obj_ids):
+def fetch_objects(obj_class, obj_ids, keep_order=True):
     objs = []
     # Fetch objects by 30 items,
     # so we won't bump into HTTP request length limits
@@ -42,7 +42,17 @@ def fetch_objects(obj_class, obj_ids):
         response = requests.get(api_url,
                                 headers={'Authorization': 'Bearer ' + token}
                                 ).json()
+
         objs += response['{}s'.format(obj_class)]
+    if (keep_order):
+        # Permute `objs` to keep the order from `obj_ids`
+        n = len(objs) # should be equal to len(obj_ids)
+        perm_ids = sorted(range(n), key=lambda i: obj_ids[i]) # sorted(obj_ids) == [obj_ids[perm_ids[i]] for i in range(n)]
+        perm_objs = sorted(range(n), key=lambda i: objs[i]['id']) # sorted(objs, key=lambda x: x['id']) == [objs[perm_objs[i]] for i in range(n)]
+        res = n*[None]
+        for i in range(n):
+            res[perm_ids[i]] = objs[perm_objs[i]]
+        return res
     return objs
 
 

--- a/examples/save_course_steps.py
+++ b/examples/save_course_steps.py
@@ -45,14 +45,7 @@ def fetch_objects(obj_class, obj_ids, keep_order=True):
 
         objs += response['{}s'.format(obj_class)]
     if (keep_order):
-        # Permute `objs` to keep the order from `obj_ids`
-        n = len(objs) # should be equal to len(obj_ids)
-        perm_ids = sorted(range(n), key=lambda i: obj_ids[i]) # sorted(obj_ids) == [obj_ids[perm_ids[i]] for i in range(n)]
-        perm_objs = sorted(range(n), key=lambda i: objs[i]['id']) # sorted(objs, key=lambda x: x['id']) == [objs[perm_objs[i]] for i in range(n)]
-        res = n*[None]
-        for i in range(n):
-            res[perm_ids[i]] = objs[perm_objs[i]]
-        return res
+        return sorted(objs, key=lambda x: obj_ids.index(x['id']))
     return objs
 
 


### PR DESCRIPTION
Make `fetch_objects` return objects in the same order (by `id`) as in the argument `obj_ids`, if the option `keep_order` is True. This fixes issue #49 (see also #52).
